### PR TITLE
Fix #1 Close connection only when doc is closed

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -55,7 +55,7 @@ class OnMessage {
             this.updateEditorText(request.text);
 
             this.disposables.push(workspace.onDidCloseTextDocument((doc) => {
-              if(doc == this.document) {
+              if(doc == this.document && doc.isClosed) {
                 this.closed = true;
                 this.webSocketConnection.close();
                 this.doCleanup();


### PR DESCRIPTION
Fix #1 

When language setting is changed, the dispose event is triggered in VSCode, and thus onDidCloseTextDocument is fired.
I changed to check if the document is closed.

@jtokoph, I would like you to review. 
Thanks.